### PR TITLE
Create GitHub workflow to close stale issues

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -1,0 +1,22 @@
+name: Stale and close inactive issues
+on:
+  schedule:
+    - cron: "0 1 * * *"
+    
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 250
+          exempt-issue-labels: "in progress"
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-stale: 30
+          days-before-issue-close: 5
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 5 days since being marked as stale."


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Create a GitHub workflow that automatically marks issues as stale after 30 days of inactivity and closes them 5 days after being marked as stale.

### Why are these changes being made?

This workflow is implemented to manage and clean up inactive issues in the repository, reducing clutter and helping maintain focus on active issues. By using a cron schedule and setting specific conditions, it automates the process to ensure that issues with no recent activity are reviewed and closed systematically, ensuring better resource allocation and project management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->